### PR TITLE
Change link numbers to short names

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,9 @@ Pydot versions since 1.4.2 adhere to [PEP 440-style semantic versioning]
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Added:
+- Add standard Python logging, using the logger name `pydot`. For
+  details, see the new section on Troubleshooting in README.md.
 
 
 2.0.0 (2023-12-30)

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ About
 
 `pydot`:
 
-  - is an interface to [Graphviz][1],
-  - can parse and dump into the [DOT language][2] used by GraphViz,
+  - is an interface to [Graphviz][gv],
+  - can parse and dump into the [DOT language][wiki_dot] used by GraphViz,
   - is written in pure Python,
 
-and [`networkx`][3] can convert its graphs to `pydot`.
+and [`networkx`][networkx] can convert its graphs to `pydot`.
 
-Development occurs at [GitHub][4], where you can report issues and
+Development occurs at [GitHub][pydot_gh], where you can report issues and
 contribute code.
 
 
@@ -34,7 +34,7 @@ start with. Here are 3 common options:
 
     Use this method if you already have a DOT-file describing a graph,
     for example as output of another program. Let's say you already
-    have this `example.dot` (based on an [example from Wikipedia][5]):
+    have this `example.dot` (based on an [example from Wikipedia][wiki_example]):
 
     ```dot
     graph my_graph {
@@ -199,13 +199,13 @@ For more help, see the docstrings of the various pydot objects and
 methods. For example, `help(pydot)`, `help(pydot.Graph)` and
 `help(pydot.Dot.write)`.
 
-More [documentation contributions welcome][6].
+More [documentation contributions welcome][contrib].
 
 
 Installation
 ============
 
-From [PyPI][7] using [`pip`][8]:
+From [PyPI][pypi] using [`pip`][pip]:
 
 `pip install pydot`
 
@@ -217,13 +217,13 @@ From source:
 Dependencies
 ============
 
-- [`pyparsing`][9]: used only for *loading* DOT files,
+- [`pyparsing`][pyparsing]: used only for *loading* DOT files,
   installed automatically during `pydot` installation.
 
 - GraphViz: used to render graphs as PDF, PNG, SVG, etc.
   Should be installed separately, using your system's
-  [package manager][10], something similar (e.g., [MacPorts][11]),
-  or from [its source][12].
+  [package manager][pkg], something similar (e.g., [MacPorts][mac]),
+  or from [its source][src].
 
 
 Troubleshooting
@@ -250,8 +250,8 @@ cause the log to become very large or contain sensitive information.
 Advanced logging configuration
 ------------------------------
 
-- Check out the [Python logging documentation][13] and the
-  [`logging_tree`][14] visualizer.
+- Check out the [Python logging documentation][log] and the
+  [`logging_tree`][log_tree] visualizer.
 - `pydot` does not add any handlers to its loggers, nor does it setup
   or modify your root logger. The `pydot` loggers are created with the
   default level `NOTSET`.
@@ -265,7 +265,7 @@ Advanced logging configuration
 License
 =======
 
-Distributed under an [MIT license][15].
+Distributed under an [MIT license][NIT].
 
 
 Contacts
@@ -281,18 +281,18 @@ Past maintainers:
 Original author: Ero Carrera <ero (dot) carrera (at) gmail (dot) com>
 
 
-[1]: https://www.graphviz.org
-[2]: https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29
-[3]: https://github.com/networkx/networkx
-[4]: https://github.com/pydot/pydot
-[5]: https://en.wikipedia.org/w/index.php?title=DOT_(graph_description_language)&oldid=1003001464#Attributes
-[6]: https://github.com/pydot/pydot/issues/130
-[7]: https://pypi.org/project/pydot/
-[8]: https://github.com/pypa/pip
-[9]: https://github.com/pyparsing/pyparsing
-[10]: https://en.wikipedia.org/wiki/Package_manager
-[11]: https://www.macports.org
-[12]: https://gitlab.com/graphviz/graphviz
-[13]: https://docs.python.org/3/library/logging.html
-[14]: https://pypi.org/project/logging_tree/
-[15]: https://github.com/pydot/pydot/blob/master/LICENSE
+[gv]: https://www.graphviz.org
+[wiki_dot]: https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29
+[networkx]: https://github.com/networkx/networkx
+[pydot_gh]: https://github.com/pydot/pydot
+[wiki_example]: https://en.wikipedia.org/w/index.php?title=DOT_(graph_description_language)&oldid=1003001464#Attributes
+[contrib]: https://github.com/pydot/pydot/issues/130
+[pypi]: https://pypi.org/project/pydot/
+[pip]: https://github.com/pypa/pip
+[pyparsing]: https://github.com/pyparsing/pyparsing
+[pkg]: https://en.wikipedia.org/wiki/Package_manager
+[mac]: https://www.macports.org
+[src]: https://gitlab.com/graphviz/graphviz
+[log]: https://docs.python.org/3/library/logging.html
+[log_tree]: https://pypi.org/project/logging_tree/
+[MIT]: https://github.com/pydot/pydot/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ About
 
 and [`networkx`][3] can convert its graphs to `pydot`.
 
-Development occurs at [GitHub][11], where you can report issues and
+Development occurs at [GitHub][4], where you can report issues and
 contribute code.
 
 
@@ -34,7 +34,7 @@ start with. Here are 3 common options:
 
     Use this method if you already have a DOT-file describing a graph,
     for example as output of another program. Let's say you already
-    have this `example.dot` (based on an [example from Wikipedia][12]):
+    have this `example.dot` (based on an [example from Wikipedia][5]):
 
     ```dot
     graph my_graph {
@@ -199,13 +199,13 @@ For more help, see the docstrings of the various pydot objects and
 methods. For example, `help(pydot)`, `help(pydot.Graph)` and
 `help(pydot.Dot.write)`.
 
-More [documentation contributions welcome][13].
+More [documentation contributions welcome][6].
 
 
 Installation
 ============
 
-From [PyPI][4] using [`pip`][5]:
+From [PyPI][7] using [`pip`][8]:
 
 `pip install pydot`
 
@@ -217,19 +217,55 @@ From source:
 Dependencies
 ============
 
-- [`pyparsing`][6]: used only for *loading* DOT files,
+- [`pyparsing`][9]: used only for *loading* DOT files,
   installed automatically during `pydot` installation.
 
 - GraphViz: used to render graphs as PDF, PNG, SVG, etc.
   Should be installed separately, using your system's
-  [package manager][7], something similar (e.g., [MacPorts][8]),
-  or from [its source][9].
+  [package manager][10], something similar (e.g., [MacPorts][11]),
+  or from [its source][12].
+
+
+Troubleshooting
+===============
+
+How to enable logging
+---------------------
+
+`pydot` uses Python's standard `logging` module. To see the logs,
+assuming logging has not been configured already:
+
+    >>> import logging
+    >>> logging.basicConfig(level=logging.DEBUG)
+    >>> import pydot
+    DEBUG:pydot:pydot initializing
+    DEBUG:pydot:pydot <version>
+    DEBUG:pydot.core:pydot core module initializing
+    DEBUG:pydot.dot_parser:pydot dot_parser module initializing
+
+**Warning**: When `DEBUG` level logging is enabled, `pydot` may log the
+data that it processes, such as graph contents or DOT strings. This can
+cause the log to become very large or contain sensitive information.
+
+Advanced logging configuration
+------------------------------
+
+- Check out the [Python logging documentation][13] and the
+  [`logging_tree`][14] visualizer.
+- `pydot` does not add any handlers to its loggers, nor does it setup
+  or modify your root logger. The `pydot` loggers are created with the
+  default level `NOTSET`.
+- `pydot` registers the following loggers:
+  - `pydot`: Parent logger. Emits a few messages during startup.
+  - `pydot.core`: Messages related to pydot objects, Graphviz execution
+                  and anything else not covered by the other loggers.
+  - `pydot.dot_parser`: Messages related to the parsing of DOT strings.
 
 
 License
 =======
 
-Distributed under an [MIT license][10].
+Distributed under an [MIT license][15].
 
 
 Contacts
@@ -248,13 +284,15 @@ Original author: Ero Carrera <ero (dot) carrera (at) gmail (dot) com>
 [1]: https://www.graphviz.org
 [2]: https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29
 [3]: https://github.com/networkx/networkx
-[4]: https://pypi.python.org/pypi
-[5]: https://github.com/pypa/pip
-[6]: https://github.com/pyparsing/pyparsing
-[7]: https://en.wikipedia.org/wiki/Package_manager
-[8]: https://www.macports.org
-[9]: https://gitlab.com/graphviz/graphviz
-[10]: https://github.com/pydot/pydot/blob/master/LICENSE
-[11]: https://github.com/pydot/pydot
-[12]: https://en.wikipedia.org/w/index.php?title=DOT_(graph_description_language)&oldid=1003001464#Attributes
-[13]: https://github.com/pydot/pydot/issues/130
+[4]: https://github.com/pydot/pydot
+[5]: https://en.wikipedia.org/w/index.php?title=DOT_(graph_description_language)&oldid=1003001464#Attributes
+[6]: https://github.com/pydot/pydot/issues/130
+[7]: https://pypi.org/project/pydot/
+[8]: https://github.com/pypa/pip
+[9]: https://github.com/pyparsing/pyparsing
+[10]: https://en.wikipedia.org/wiki/Package_manager
+[11]: https://www.macports.org
+[12]: https://gitlab.com/graphviz/graphviz
+[13]: https://docs.python.org/3/library/logging.html
+[14]: https://pypi.org/project/logging_tree/
+[15]: https://github.com/pydot/pydot/blob/master/LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dev = [
 ]
 tests = [
   'chardet',
-  'black',
   'tox',
   'parameterized',
   'unittest-parallel',

--- a/src/pydot/__init__.py
+++ b/src/pydot/__init__.py
@@ -1,8 +1,16 @@
 """An interface to GraphViz."""
 
+import logging
+
 __author__ = "Ero Carrera"
 __version__ = "2.0.1.dev0"
 __license__ = "MIT"
 
-from pydot.exceptions import *
-from pydot.core import *
+
+_logger = logging.getLogger(__name__)
+_logger.debug("pydot initializing")
+_logger.debug("pydot %s", __version__)
+
+
+from pydot.exceptions import *  # noqa: E402, F403
+from pydot.core import *  # noqa: F403, E402

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -3,6 +3,7 @@
 import copy
 import io
 import errno
+import logging
 import os
 import re
 import subprocess
@@ -11,6 +12,11 @@ import tempfile
 import warnings
 
 import pydot
+
+
+_logger = logging.getLogger(__name__)
+_logger.debug("pydot core module initializing")
+
 
 try:
     from pydot import dot_parser

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -8,6 +8,8 @@ Author: Michael Krause <michael@krause-software.de>
 Fixes by: Ero Carrera <ero.carrera@gmail.com>
 """
 
+import logging
+
 from pyparsing import (
     CaselessLiteral,
     CharsNotIn,
@@ -31,6 +33,10 @@ import pydot
 
 __author__ = ["Michael Krause", "Ero Carrera"]
 __license__ = "MIT"
+
+
+_logger = logging.getLogger(__name__)
+_logger.debug("pydot dot_parser module initializing")
 
 
 class P_AttrList(object):

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -5,8 +5,8 @@
 # -test del_node, del_edge methods
 # -test Common.set method
 import argparse
-import datetime
 from hashlib import sha256
+import importlib
 import functools
 import io
 import os
@@ -427,6 +427,22 @@ class TestGraphAPI(PydotTestCase):
 
     def test_version(self):
         self.assertIsInstance(pydot.__version__, str)
+
+    def test_logging_init(self):
+        with self.assertLogs("pydot", level="DEBUG") as cm:
+            importlib.reload(pydot)
+            importlib.reload(pydot.core)
+            importlib.reload(pydot.dot_parser)
+        self.assertEqual(
+            cm.output,
+            [
+                "DEBUG:pydot:pydot initializing",
+                "DEBUG:pydot:pydot %s" % pydot.__version__,
+                "DEBUG:pydot.core:pydot core module initializing",
+                "DEBUG:pydot.dot_parser:pydot dot_parser module initializing",
+            ],
+        )
+        importlib.reload(pydot)
 
 
 class TestShapeFiles(PydotTestCase):


### PR DESCRIPTION
A suggestion for your (very old, but meh) logging PR. I saw you were renumbering the links in the README — IMHO, using numbers is just a way to make yourself crazy. This replaces all of the numbered links with short names. (The longest is `wiki_example`, many others are only 2-5 characters. Still way more evocative and maintainable than numbers.)